### PR TITLE
Add cst-dependencies rep to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
         url "https://artifacts.camunda.com/artifactory/public/"
     }
     maven { url 'https://jitpack.io' }
+    maven {
+        url 'https://cst-group.github.io/cst-dependencies/maven-repo/'
+    }
 }
 
 configurations {
@@ -31,27 +34,19 @@ configurations {
 }
 
 dependencies {
-    //api('com.github.CST-Group:cst:e93dc57')
     api('com.github.CST-Group:cst-bindings:1.1.0')
-    //api ':cst-bindings:1.0.6-full'
     api group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
     api 'com.soartech:jsoar-core:4.1.3'
     api 'com.soartech:jsoar-debugger:4.1.3'
-    //api 'org.ros.rosjava_core:rosjava:0.3.6'
-    //implementation 'com.github.rosjava:rosjava_core:0.3.7'
     api group: 'net.sf.jung', name: 'jung-algorithms', version: '2.0.1'
     api group: 'net.sf.jung', name: 'jung-graph-impl', version: '2.0.1'
     api group: 'net.sf.jung', name: 'jung-visualization', version: '2.0.1'
     api group: 'net.sf.jung', name: 'jung-api', version: '2.0.1'
-    api 'com.github.rosjava:rosjava_core:0.3.7'
-    api 'org.ros.rosjava_bootstrap:message_generation:0.3.3'
     testImplementation 'com.github.CST-Group:cst:e93dc57'
     testImplementation 'com.1stleg:jnativehook:2.1.0'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testImplementation 'org.ros.rosjava_messages:std_msgs:0.5.11'
-    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
Due to https://spring.io/blog/2024/12/02/repository-springsource-com-sunset some of the dependencies were missing so we added the libs to https://github.com/CST-Group/cst-dependencies